### PR TITLE
migrate to nest v7 custom route decorator

### DIFF
--- a/generators/server/templates/server/src/security/decorators/auth-user.decorator.ts.ejs
+++ b/generators/server/templates/server/src/security/decorators/auth-user.decorator.ts.ejs
@@ -1,3 +1,8 @@
-import { createParamDecorator } from '@nestjs/common';
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
 
-export const AuthUser = createParamDecorator((data, request) => request.user);
+export const AuthUser = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.user;
+  },
+);


### PR DESCRIPTION
Addition to https://github.com/jhipster/generator-jhipster-nodejs/issues/183 

Relevant migration guide docs section: https://docs.nestjs.com/migration-guide#custom-route-decorators