### PR TITLE
Update user language

### DIFF
--- a/generators/server/templates/server/src/service/auth.service.ts.ejs
+++ b/generators/server/templates/server/src/service/auth.service.ts.ejs
@@ -108,6 +108,7 @@ export class AuthService {
     userFind.firstName = newUserInfo.firstName;
     userFind.lastName = newUserInfo.lastName;
     userFind.email = newUserInfo.email;
+    userFind.langKey = newUserInfo.langKey;
     await this.userService.save(userFind);
     return;
   }


### PR DESCRIPTION
The user form generated has a field to select the language to be used on the site, but that field is not being saved because it is not being handled by the `authService.updateUserSettings()`.