### PR TITLE
Feature/class interceptor

### DIFF
--- a/generators/entity-server/templates/server/src/web/rest/entity.controller.ts.ejs
+++ b/generators/entity-server/templates/server/src/web/rest/entity.controller.ts.ejs
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Logger, Param, Post as PostMethod, Put, UseGuards, Req, UseInterceptors } from '@nestjs/common';
+import { Body, ClassSerializerInterceptor, Controller, Delete, Get, Logger, Param, Post as PostMethod, Put, UseGuards, Req, UseInterceptors } from '@nestjs/common';
 import { <% if (authenticationType === 'jwt') { _%> ApiBearerAuth, <% } else if (authenticationType === 'oauth2') { _%> ApiOAuth2Auth, <% } _%> ApiUseTags, ApiResponse, ApiOperation } from '@nestjs/swagger';
 import { <%= entityClass %>DTO } from '../../service/dto/<%= entityFileName %>.dto';
 import { <%= entityClass %>Service } from '../../service/<%= entityFileName %>.service';
@@ -14,7 +14,7 @@ _%>
 
 @Controller('api/<%= entityApiUrl %>')
 @UseGuards(AuthGuard, RolesGuard)
-@UseInterceptors(LoggingInterceptor)
+@UseInterceptors(LoggingInterceptor, ClassSerializerInterceptor)
 <%_ if (authenticationType === 'jwt') { _%>
 @ApiBearerAuth()
 <%_ } else if (authenticationType === 'oauth2') { _%>

--- a/generators/server/templates/server/src/web/rest/public.user.controller.ts.ejs
+++ b/generators/server/templates/server/src/web/rest/public.user.controller.ts.ejs
@@ -1,4 +1,4 @@
-import { Controller, Get, Logger, Req, UseInterceptors } from '@nestjs/common';
+import { Controller, ClassSerializerInterceptor, Get, Logger, Req, UseInterceptors } from '@nestjs/common';
 import { LoggingInterceptor } from '../../client/interceptors/logging.interceptor';
 import { PageRequest, Page } from '../../domain/base/pagination.entity';
 import { UserDTO } from '../../service/dto/user.dto';
@@ -8,7 +8,7 @@ import { ApiUseTags, ApiResponse, ApiOperation } from '@nestjs/swagger';
 import { AuthService } from '../../service/auth.service';
 
 @Controller('api')
-@UseInterceptors(LoggingInterceptor)
+@UseInterceptors(LoggingInterceptor, ClassSerializerInterceptor)
 @ApiUseTags('public-user-controller')
 export class PublicUserController {
 


### PR DESCRIPTION
I noticed that there are still some controllers which include (hashed) passwords in their results. I have identified the public user controller and the entity controller (for users which are connected via a relationship) and added the `ClassSerializerInterceptor` so that the `@Exclude()` annotation on the user DTO password field is respected for these controlelrs too.