### PR TITLE
Added webpack-merge package to devDependencies in the Angular generator.

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -131,7 +131,8 @@
     "typescript": "<%= dependabotPackageJson.devDependencies['typescript'] %>",
     "webpack": "<%= dependabotPackageJson.devDependencies['webpack'] %>",
     "webpack-bundle-analyzer": "<%= dependabotPackageJson.devDependencies['webpack-bundle-analyzer'] %>",
-    "webpack-notifier": "<%= dependabotPackageJson.devDependencies['webpack-notifier'] %>"
+    "webpack-notifier": "<%= dependabotPackageJson.devDependencies['webpack-notifier'] %>",
+    "webpack-merge": "<%= dependabotPackageJson.devDependencies['webpack-merge'] %>"
   },
   "engines": {
     "node": ">=<%= NODE_VERSION %>"


### PR DESCRIPTION
`ng serve` failed with missing dependency for `webpack-merge`. I added the following to the end of the devDependencies and `ng serve` worked.

```
"webpack-merge": "^5.8.0"
```

I only updated the Angular generator. YMMV with other frontends.