### PR TITLE
update non major versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
     schedule:
       interval: 'daily'
     open-pull-requests-limit: 10
+    update-types:
+      - 'minor'
+      - 'patch'
     groups:
       jest:
         patterns:


### PR DESCRIPTION
Dependabot is blocked for major versions updates so update minor and patch dependencies only for now

related to https://github.com/jhipster/generator-jhipster-nodejs/issues/349 and https://github.com/jhipster/generator-jhipster-nodejs/issues/538