### PR TITLE
Fix: bump typescript-eslint from 8.58.2 to 8.59.1 in /generators/node-server/resources

### DIFF
--- a/generators/node-server/resources/package.json
+++ b/generators/node-server/resources/package.json
@@ -63,7 +63,7 @@
     "tsc-watch": "7.2.0",
     "tsconfig-paths": "4.2.0",
     "typescript": "5.9.3",
-    "typescript-eslint": "8.58.2"
+    "typescript-eslint": "8.59.1"
   },
   "packageManager": "npm@11"
 }

--- a/generators/node-server/templates/server/e2e/user.e2e-spec.ts.ejs
+++ b/generators/node-server/templates/server/e2e/user.e2e-spec.ts.ejs
@@ -114,7 +114,7 @@ describe('User', () => {
             .delete('/api/admin/users/' + savedUser.login)
             .expect(204);
 
-        const userUndefined = await service.findById(savedUser.id as any);
+        const userUndefined = await service.findById(savedUser.id);
         expect(userUndefined).toBeUndefined();
     });
 


### PR DESCRIPTION
Fix #1204 